### PR TITLE
Parsec.Parsec: Change UpgradeBehavior

### DIFF
--- a/manifests/p/Parsec/Parsec/150.93.2.0/Parsec.Parsec.installer.yaml
+++ b/manifests/p/Parsec/Parsec/150.93.2.0/Parsec.Parsec.installer.yaml
@@ -8,7 +8,7 @@ InstallerType: nullsoft
 InstallerSwitches:
   Silent: /silent /norun /nocleanuser
   SilentWithProgress: /silent /nocleanuser
-UpgradeBehavior: uninstallPrevious
+UpgradeBehavior: deny
 Installers:
 - Architecture: x64
   InstallerUrl: https://builds.parsec.app/package/parsec-windows.exe


### PR DESCRIPTION
Change UpgradeBehavior to "deny" because Parsec updates itself. This fixes issue https://github.com/microsoft/winget-pkgs/issues/97301

Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [x] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.6 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.6.0)?

Note: `<path>` is the name of the directory containing the manifest you're submitting.

---
